### PR TITLE
Function get_all_projects now return a dict when there are no projects, fixing broken empty browse page.

### DIFF
--- a/byteguide/libs/fs.py
+++ b/byteguide/libs/fs.py
@@ -316,7 +316,7 @@ class DocsDirScanner:
         docfiles_dir = docfiles_dir or config.docfiles_dir
 
         if not docfiles_dir.is_dir():
-            return []
+            return {}
 
         all_projects: t.List[ProjectEntry] = get_directory_listing(path=docfiles_dir)
 


### PR DESCRIPTION
The browse page could not be viewed when there are no projects since the get_all_projects function then return an empty list. A list has no .values() attribute which is what is used in the browse.html file. This caused UndefinedError exception to be raised.

![image](https://github.com/ninadmhatre/byteguide/assets/54413402/07380ae7-229a-4a26-ac51-c67bb3217093)

Now a dict is returned when there are no projects so that the page can still be viewed empty 😊