### PR TITLE
Set default to list for json.dump to get tag list to work and fixed error when handling projects with no versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: poetry-${{ env.POETRY_VERSION }}
+          key: poetry-${{ env.POETRY_VERSION }}-${{ matrix.python-version }}-${{ runner.os }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: pydeps-${{ hashFiles('**/poetry.lock') }}
+          key: pydeps-${{ hashFiles('**/poetry.lock') }}-${{ env.POETRY_VERSION }}-${{ matrix.python-version }}-${{ runner.os }}
 
       # `--no-root` means "install all dependencies but not the project
       # itself", which is what you want to avoid caching _your_ code. The `if` statement

--- a/byteguide/libs/dtypes.py
+++ b/byteguide/libs/dtypes.py
@@ -52,6 +52,10 @@ class ProjectEntry:  # pylint: disable=too-few-public-methods
         with open(metadata_path, "r", encoding="utf-8") as f:
             data = json.load(f)
 
+        if not data.get("versions"):
+            log.warning(f"Project {self.path} metadata does not contain any versions")
+            return data
+
         versions = []
 
         for ver, ver_meta in data["versions"].items():

--- a/byteguide/libs/fs.py
+++ b/byteguide/libs/fs.py
@@ -363,7 +363,7 @@ class MetaDataHandler:
         metadata_file = self._get_metadata_file()
 
         with open(metadata_file, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=4)
+            json.dump(metadata, f, indent=4, default=list)
 
 
 class DocsDirScanner:

--- a/byteguide/libs/fs.py
+++ b/byteguide/libs/fs.py
@@ -291,7 +291,7 @@ class MetaDataHandler:
 
         # Convert tags, if any, to lowercase and remove duplicates
         if "tags" in metadata:
-            metadata["tags"] = {tag.lower() for tag in metadata["tags"]}
+            metadata["tags"] = [tag.lower() for tag in metadata["tags"]]
 
         # convert programming language to lowercase
         if "programming-lang" in metadata:
@@ -363,7 +363,7 @@ class MetaDataHandler:
         metadata_file = self._get_metadata_file()
 
         with open(metadata_file, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=4, default=list)
+            json.dump(metadata, f, indent=4)
 
 
 class DocsDirScanner:

--- a/byteguide/routes/manage.py
+++ b/byteguide/routes/manage.py
@@ -56,9 +56,9 @@ def register():
     dir_scan = DocsDirScanner()
 
     all_projects = dir_scan.get_all_projects()
-    exsting_projs = [proj.lower() for proj in all_projects]
+    existing_projs = [proj.lower() for proj in all_projects]
 
-    if proj_path.exists() or proj_name.lower() in exsting_projs:
+    if proj_path.exists() or proj_name.lower() in existing_projs:
         proj_json = metadata_handler.read_metadata()
         result["message"] = f"project ['{proj_name.lower()}'] already registered!"
         result["unique-key"] = proj_json["unique-key"]

--- a/byteguide/routes/manage.py
+++ b/byteguide/routes/manage.py
@@ -108,7 +108,7 @@ def upload():
     try:
         uploaded_file = util.file_from_request(request)
         status = uploader.upload(uploaded_file, uniq_key=unique_key, reupload=reupload)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e: # pylint: disable=broad-except
         log.error(e)
         response = {"status": "failed", "message": str(e)}
     else:

--- a/byteguide/routes/manage.py
+++ b/byteguide/routes/manage.py
@@ -108,7 +108,7 @@ def upload():
     try:
         uploaded_file = util.file_from_request(request)
         status = uploader.upload(uploaded_file, uniq_key=unique_key, reupload=reupload)
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         log.error(e)
         response = {"status": "failed", "message": str(e)}
     else:

--- a/byteguide/routes/manage.py
+++ b/byteguide/routes/manage.py
@@ -99,8 +99,8 @@ def upload():
     if not request.files:
         return jsonify({"status": "failed", "message": "Request is missing a zip file."}), 400
 
-    unique_key = request.args.get("unique-key", None)
-    reupload = request.args.get("reupload", "false")
+    unique_key = request.form.get("unique-key", None)
+    reupload = request.form.get("reupload", "false")
 
     reupload = reupload.lower() == "true"
 


### PR DESCRIPTION
Without this I got broken json when uploading an example project with a list of tags.

Resulting metadata.json

```
{
    "name": "Sample-Proj",
    "description": "This is a sample project",
    "owner": "Carl Westman",
    "owner-email": "test@google.com",
    "programming-lang": "python",
    "tags": 
```

Which resulted in weird errors down the line because the json was broken.

With this change I get the following metadata.json

```
{
    "name": "Sample-Proj",
    "description": "This is a sample project",
    "owner": "Carl Westman",
    "owner-email": "test@google.com",
    "programming-lang": "python",
    "tags": [
        "project",
        "sample",
        "python"
    ],
    "unique-key": "743b92dc-ee45-4671-966a-0e8fa5def464"
}
```

EDIT: Fixed a lurking pylint error as well, to get pipeline to pass

EDIT2: Fixed error where going into the browse page with a registered project with no versions would cause

```
  File "/home/azureuser/byteguide/byteguide/routes/display.py", line 23, in browse_all
    projects = docs_dir_scanner.get_all_projects()
  File "/home/azureuser/byteguide/byteguide/libs/fs.py", line 454, in get_all_projects
    all_projects: t.List[ProjectEntry] = get_directory_listing(path=docfiles_dir)
  File "/home/azureuser/byteguide/byteguide/libs/util.py", line 72, in get_directory_listing
    result.append(ProjectEntry(entry))
  File "/home/azureuser/byteguide/byteguide/libs/dtypes.py", line 34, in __init__
    self.metadata = self._load_metadata()
  File "/home/azureuser/byteguide/byteguide/libs/dtypes.py", line 56, in _load_metadata
    for ver, ver_meta in data["versions"].items():
KeyError: 'versions'
```

EDIT3: In /upload route the requests.args variable was checked for `unique-key` and `reupload`. Args is however empty when using -F with curl, they can be found in requests.form 

![image](https://github.com/ninadmhatre/byteguide/assets/54413402/76836a40-5951-4dde-bd29-8389db4d20fd)
